### PR TITLE
Fixed python3 deprecation warnings in test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -14,25 +14,25 @@ class TestApp(unittest.TestCase):
     def test_home_page_works(self):
         rv = self.app.get('/')
         self.assertTrue(rv.data)
-        self.assertEquals(rv.status_code, 200)
+        self.assertEqual(rv.status_code, 200)
 
     def test_about_page_works(self):
         rv = self.app.get('/about/')
         self.assertTrue(rv.data)
-        self.assertEquals(rv.status_code, 200)
+        self.assertEqual(rv.status_code, 200)
 
     def test_default_redirecting(self):
         rv = self.app.get('/about')
-        self.assertEquals(rv.status_code, 301)
+        self.assertEqual(rv.status_code, 301)
 
     def test_404_page(self):
         rv = self.app.get('/i-am-not-found/')
-        self.assertEquals(rv.status_code, 404)
+        self.assertEqual(rv.status_code, 404)
 
     def test_static_text_file_request(self):
         rv = self.app.get('/robots.txt')
         self.assertTrue(rv.data)
-        self.assertEquals(rv.status_code, 200)
+        self.assertEqual(rv.status_code, 200)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When running with `Python3.3.3` lines 17, 22, 26, 30 and 35 are triggering this warning:

``` python
test.py:N: DeprecationWarning: Please use assertEqual instead.
```

After this fix the tests still pass cleanly under `Python 2.7.6`, but I get this:

``` python
..../usr/lib64/python3.3/unittest/case.py:384: ResourceWarning: unclosed file <_io.BufferedReader name='.../flask_heroku/static/robots.txt'>
  function()
.
```

which I am guessing is an issue with flask or unittest.
