### PR TITLE
Fixed python3 ResourceWarning in test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -33,6 +33,7 @@ class TestApp(unittest.TestCase):
         rv = self.app.get('/robots.txt')
         self.assertTrue(rv.data)
         self.assertEqual(rv.status_code, 200)
+        rv.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A fix for the ResourceWarning mentioned in #12.

All of your tests now pass cleanly on both `Python 3.3.3` and `Python 2.7.6`.
