### PR TITLE
Removed deprecated --no-site-packages option from virtualenv setup documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Ruby gem](http://devcenter.heroku.com/articles/using-the-cli).
 
 Now, you can setup an isolated environment with `virtualenv`.
 
-    $ virtualenv --no-site-packages env
+    $ virtualenv env
     $ source env/bin/activate
 
 


### PR DESCRIPTION
--no-site-packages option is now the default.  Simplifying documentation.
